### PR TITLE
Adds telemetry device status producer

### DIFF
--- a/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
+++ b/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
@@ -68,5 +68,13 @@
             public const double DEFAULT_LOCATION_LAT = 0.0;
             public const double DEFAULT_LOCATION_LON = 0.0;
         }
+
+        public static class Quartz
+        {
+            public const int TELEMETRY_DEVICE_STATUS_UPDATE_JOB_INTERVAL = 5;
+            public const string TELEMETRY_DEVICE_STATUS_UPDATE_JOB_KEY = "TelemetryDeviceStatusJob";
+            public const string TELEMETRY_DEVICE_STATUS_UPDATE_TRIGGER_KEY = "TelemetryDeviceStatusTrigger";
+            public const string TELEMETRY_DEVICE_STATUS_UPDATE_GROUP_NAME = "TelemetryDeviceStatusGroup";
+        }
     }
 }

--- a/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
+++ b/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
@@ -11,6 +11,11 @@
             public const string AND_SEPERATOR_END = ")";
         }
 
+        public static class TextHelpers
+        {
+            public const string LINE_DOWN_SEPARATOR = "\n";
+        }
+
         public static class Config
         {
             public const string ICD_DIRECTORY = "ICD";

--- a/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
+++ b/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
@@ -30,6 +30,7 @@
         {
             public const string NETWORKING_SECTION = "Networking";
             public const string KAFKA = "Kafka";
+            public const string TELEMETRY_DEVICE_STATUS_SECTION = "TelemetryDeviceStatusUpdate";
         }
 
         public static class Kafka

--- a/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
+++ b/TelemetryDevice/Common/TelemetryDeviceConstatns.cs
@@ -31,6 +31,7 @@
         {
             public const string BASE_TOPIC_NAME = "telemetry-tailId-";
             public const int REPLICATION_FACTOR = 1;
+            public const string TELEMETRY_DEVICE_STATUS_TOPIC = "telemetry-devices-status";
         }
 
         public static class TelemetryCompression

--- a/TelemetryDevice/Config/TelemetryDeviceStatusConfiguration.cs
+++ b/TelemetryDevice/Config/TelemetryDeviceStatusConfiguration.cs
@@ -1,0 +1,14 @@
+﻿namespace TelemetryDevices.Config
+{
+    public class TelemetryDeviceStatusConfiguration
+    {
+        public int JobInterval { get; set; }
+        public string TopicName { get; set; }
+        public TelemetryDeviceStatusConfiguration() { }
+        public TelemetryDeviceStatusConfiguration(int jobInterval, string topicName)
+        {
+            JobInterval = jobInterval;
+            TopicName = topicName;
+        }
+    }
+}

--- a/TelemetryDevice/Dto/TelemetryDeviceStatusDto.cs
+++ b/TelemetryDevice/Dto/TelemetryDeviceStatusDto.cs
@@ -1,0 +1,18 @@
+using TelemetryDevices.Models;
+
+namespace TelemetryDevices.Dto
+{
+    public class TelemetryDeviceStatusDto
+    {
+        public int TailId { get; set; }
+        public Location Location { get; set; }
+
+        public TelemetryDeviceStatusDto() { }
+
+        public TelemetryDeviceStatusDto(TelemetryDevice telemetryDevice)
+        {
+            TailId = telemetryDevice.TailId;
+            Location = telemetryDevice.Location;
+        }
+    }
+}

--- a/TelemetryDevice/Extensions/ByteArrayExtensions.cs
+++ b/TelemetryDevice/Extensions/ByteArrayExtensions.cs
@@ -25,10 +25,8 @@ namespace TelemetryDevices.Extensions
                     bitArray[absoluteBitPosition] =
                         (
                             bytes[byteIndex]
-                            & 
-                                TelemetryDeviceConstants.TelemetryCompression.BIT_SHIFT_BASE
+                            & TelemetryDeviceConstants.TelemetryCompression.BIT_SHIFT_BASE
                                 << bitPositionInByte
-                            
                         ) != 0;
                 }
             }

--- a/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
+++ b/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using Confluent.Kafka;
 using Core.Configuration;
 using Microsoft.Extensions.Options;
+using Quartz;
 using TelemetryDevices.Common;
 using TelemetryDevices.Config;
-using TelemetryDevices.Services.Kafka.Producers;
+using TelemetryDevices.Services.Kafka.Producers.TelemetryProducer;
 using TelemetryDevices.Services.Kafka.Topic_Manager;
 using TelemetryDevices.Services.PipeLines;
 using TelemetryDevices.Services.PipeLines.Blocks.Decoder;
@@ -97,7 +98,7 @@ namespace TelemetryDevices.Extensions
 
         public static IServiceCollection AddTelemetryDeviceManager(this IServiceCollection services)
         {
-            services.AddSingleton<TelemetryDeviceManager>();
+            services.AddSingleton<ITelemetryDeviceManager,TelemetryDeviceManager>();
             return services;
         }
 
@@ -127,6 +128,16 @@ namespace TelemetryDevices.Extensions
             });
 
             services.AddSingleton<IKafkaTopicManager, KafkaTopicManager>();
+            return services;
+        }
+
+        public static IServiceCollection AddQuartzServices(this IServiceCollection services)
+        {
+            services.AddQuartz();
+            services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
+            services.AddSingleton(provider =>
+                provider.GetRequiredService<ISchedulerFactory>()
+                    .GetScheduler().GetAwaiter().GetResult());
             return services;
         }
     }

--- a/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
+++ b/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
@@ -42,6 +42,16 @@ namespace TelemetryDevices.Extensions
             );
         }
 
+        public static IServiceCollection AddTelemetryDevicesUpdateJobConfiguration(this IServiceCollection services,
+            IConfiguration appConfiguration)
+        {
+            return services.Configure<TelemetryDeviceStatusConfiguration>(
+                appConfiguration.GetSection(
+                    TelemetryDeviceConstants.Configuration.TELEMETRY_DEVICE_STATUS_SECTION
+                )
+            );
+        }
+
         public static IServiceCollection AddKafkaServices(
             this IServiceCollection services,
             IConfiguration appConfiguration

--- a/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
+++ b/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Quartz;
 using TelemetryDevices.Common;
 using TelemetryDevices.Config;
 using TelemetryDevices.Services.Kafka.Producers.TelemetryProducer;
+using TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProducer;
 using TelemetryDevices.Services.Kafka.Topic_Manager;
 using TelemetryDevices.Services.PipeLines;
 using TelemetryDevices.Services.PipeLines.Blocks.Decoder;
@@ -14,6 +15,7 @@ using TelemetryDevices.Services.PipeLines.Blocks.Output.Kafka;
 using TelemetryDevices.Services.PipeLines.Blocks.Validator;
 using TelemetryDevices.Services.PipeLines.Blocks.Validator.CheckSum;
 using TelemetryDevices.Services.PortsManager;
+using TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager;
 using TelemetryDevices.Services.Sniffer;
 using TelemetryDevices.Services.TelemetryDevicesManager;
 
@@ -62,12 +64,26 @@ namespace TelemetryDevices.Extensions
             };
 
             services.AddSingleton(kafkaProducerConfig);
+            services.AddSingleton<IProducer<string, byte[]>>(provider =>
+            {
+                ProducerConfig config = provider.GetRequiredService<ProducerConfig>();
+                return new ProducerBuilder<string, byte[]>(config).Build();
+            });
+            
             return services;
         }
 
         public static IServiceCollection AddKafkaTelemetryProducer(this IServiceCollection services)
         {
             services.AddSingleton<IKafkaTelemetryProducer, KafkaTelemetryProducer>();
+            return services;
+        }
+
+        public static IServiceCollection AddKafkaTelemetryDeviceStatusProducer(
+            this IServiceCollection services
+        )
+        {
+            services.AddSingleton<ITelemetryDeviceStatusProducer, TelemetryDeviceStatusProducer>();
             return services;
         }
 
@@ -142,6 +158,7 @@ namespace TelemetryDevices.Extensions
                     .GetAwaiter()
                     .GetResult()
             );
+            services.AddSingleton<IQuartzTelemetryDeviceStatusManager, QuartzTelemetryDeviceStatusManager>();
             return services;
         }
     }

--- a/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
+++ b/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
@@ -98,7 +98,7 @@ namespace TelemetryDevices.Extensions
 
         public static IServiceCollection AddTelemetryDeviceManager(this IServiceCollection services)
         {
-            services.AddSingleton<ITelemetryDeviceManager,TelemetryDeviceManager>();
+            services.AddSingleton<ITelemetryDeviceManager, TelemetryDeviceManager>();
             return services;
         }
 
@@ -136,8 +136,12 @@ namespace TelemetryDevices.Extensions
             services.AddQuartz();
             services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
             services.AddSingleton(provider =>
-                provider.GetRequiredService<ISchedulerFactory>()
-                    .GetScheduler().GetAwaiter().GetResult());
+                provider
+                    .GetRequiredService<ISchedulerFactory>()
+                    .GetScheduler()
+                    .GetAwaiter()
+                    .GetResult()
+            );
             return services;
         }
     }

--- a/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
+++ b/TelemetryDevice/Extensions/ServiceCollectionExtensions.cs
@@ -69,7 +69,9 @@ namespace TelemetryDevices.Extensions
                 ProducerConfig config = provider.GetRequiredService<ProducerConfig>();
                 return new ProducerBuilder<string, byte[]>(config).Build();
             });
-            
+            AddKafkaTelemetryProducer(services);
+            AddKafkaTelemetryDeviceStatusProducer(services);
+            AddKafkaTopicManager(services);
             return services;
         }
 

--- a/TelemetryDevice/Helpers/BitManipulationHelper.cs
+++ b/TelemetryDevice/Helpers/BitManipulationHelper.cs
@@ -102,10 +102,8 @@ namespace TelemetryDevices.Helpers
             int exponentBias =
                 (
                     TelemetryDeviceConstants.TelemetryCompression.BIT_SHIFT_ONE
-                    << 
-                        exponentBitsCount
+                    << exponentBitsCount
                         - TelemetryDeviceConstants.TelemetryCompression.BIT_SHIFT_ONE
-                    
                 ) - TelemetryDeviceConstants.TelemetryCompression.BIT_SHIFT_ONE;
             return storedExponentValue - exponentBias;
         }

--- a/TelemetryDevice/Models/Location.cs
+++ b/TelemetryDevice/Models/Location.cs
@@ -10,5 +10,10 @@
             Latitude = latitude;
             Longitude = longitude;
         }
+
+        public override string ToString()
+        {
+            return $"Latitude:{Latitude}, Longitude:{Longitude}";
+        }
     }
 }

--- a/TelemetryDevice/Models/TelemetryDevice.cs
+++ b/TelemetryDevice/Models/TelemetryDevice.cs
@@ -22,5 +22,10 @@ namespace TelemetryDevices.Models
             Channels = new List<Channel>();
             TailId = tailId;
         }
+
+        public string GetStatus()
+        {
+            return $"Telemetry Device With Tail Id {TailId} located at {Location}";
+        }
     }
 }

--- a/TelemetryDevice/Models/TelemetryDevice.cs
+++ b/TelemetryDevice/Models/TelemetryDevice.cs
@@ -25,7 +25,7 @@ namespace TelemetryDevices.Models
 
         public string GetStatus()
         {
-            return $"Telemetry Device With Tail Id {TailId} located at {Location}";
+            return $"Telemetry Device With Tail Id {TailId} located at {Location.ToString()}";
         }
     }
 }

--- a/TelemetryDevice/Program.cs
+++ b/TelemetryDevice/Program.cs
@@ -16,8 +16,10 @@ builder.Services.AddICDConfiguration(builder.Configuration);
 builder.Services.AddPortManager();
 builder.Services.AddKafkaServices(builder.Configuration);
 builder.Services.AddKafkaTelemetryProducer();
+builder.Services.AddKafkaTelemetryDeviceStatusProducer();
 builder.Services.AddKafkaTopicManager();
 builder.Services.AddTelemetryPipelineServices();
+builder.Services.AddQuartzServices();
 
 WebApplication app = builder.Build();
 
@@ -33,8 +35,8 @@ IPacketSniffer sniffer = app.Services.GetRequiredService<IPacketSniffer>();
 sniffer.AddPort(TelemetryDeviceConstants.DefaultValues.DEFAULT_PORT_1);
 sniffer.AddPort(TelemetryDeviceConstants.DefaultValues.DEFAULT_PORT_2);
 
-TelemetryDeviceManager telemetryDeviceManager =
-    app.Services.GetRequiredService<TelemetryDeviceManager>();
+ITelemetryDeviceManager telemetryDeviceManager =
+    app.Services.GetRequiredService<ITelemetryDeviceManager>();
 await telemetryDeviceManager.AddTelemetryDeviceAsync(
     TelemetryDeviceConstants.DefaultValues.DEFAULT_TAIL_ID,
     [

--- a/TelemetryDevice/Program.cs
+++ b/TelemetryDevice/Program.cs
@@ -15,9 +15,6 @@ builder.Services.AddIcdDirectory();
 builder.Services.AddICDConfiguration(builder.Configuration);
 builder.Services.AddPortManager();
 builder.Services.AddKafkaServices(builder.Configuration);
-builder.Services.AddKafkaTelemetryProducer();
-builder.Services.AddKafkaTelemetryDeviceStatusProducer();
-builder.Services.AddKafkaTopicManager();
 builder.Services.AddTelemetryPipelineServices();
 builder.Services.AddQuartzServices();
 

--- a/TelemetryDevice/Program.cs
+++ b/TelemetryDevice/Program.cs
@@ -9,6 +9,7 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddWebApi();
 builder.Services.AddAppConfiguration(builder.Configuration);
+builder.Services.AddTelemetryDevicesUpdateJobConfiguration(builder.Configuration);
 builder.Services.AddPacketSniffer();
 builder.Services.AddTelemetryDeviceManager();
 builder.Services.AddIcdDirectory();

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/ITelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/ITelemetryDeviceStatusProducer.cs
@@ -1,0 +1,11 @@
+﻿using Core.Common.Enums;
+using TelemetryDevices.Models;
+
+namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProducer
+{
+    public interface ITelemetryDeviceStatusProducer
+    {
+        public Task ProduceAsync(
+            IEnumerable<TelemetryDevice> telemetryDevices);
+    }
+}

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/ITelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/ITelemetryDeviceStatusProducer.cs
@@ -5,7 +5,6 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
 {
     public interface ITelemetryDeviceStatusProducer
     {
-        public Task ProduceAsync(
-            IEnumerable<TelemetryDevice> telemetryDevices);
+        public Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices);
     }
 }

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -16,8 +16,10 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
             _kafkaTopicManager = kafkaTopicManager;
         }
 
-        public Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
+        public async Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
         {
+            await _kafkaTopicManager.EnsureTopicExistsAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC);
+
             string fullStatusMessage = string.Join(
                 TelemetryDeviceConstants.TextHelpers.LINE_DOWN_SEPARATOR,
                 telemetryDevices.Select(td => td.GetStatus())
@@ -27,9 +29,8 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
                 Key = Guid.NewGuid().ToString(),
                 Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
             };
-            _kafkaTopicManager.EnsureTopicExistsAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC);
 
-            return _producer.ProduceAsync(
+            await _producer.ProduceAsync(
                 TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC,
                 kafkaMessage
             );

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using TelemetryDevices.Common;
+using TelemetryDevices.Config;
 using TelemetryDevices.Dto;
 using TelemetryDevices.Models;
 using TelemetryDevices.Services.Kafka.Topic_Manager;
@@ -11,16 +12,21 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
     {
         private readonly IProducer<string, byte[]> _producer;
         private readonly IKafkaTopicManager _kafkaTopicManager;
+        private readonly TelemetryDeviceStatusConfiguration _telemetryDeviceStatusConfiguration;
 
-        public TelemetryDeviceStatusProducer(IProducer<string, byte[]> producer,IKafkaTopicManager kafkaTopicManager)
+        public TelemetryDeviceStatusProducer(
+            IProducer<string, byte[]> producer,
+            IKafkaTopicManager kafkaTopicManager,
+            IOptions<TelemetryDeviceStatusConfiguration> configuration)
         {
             _producer = producer;
             _kafkaTopicManager = kafkaTopicManager;
+            _telemetryDeviceStatusConfiguration = configuration.Value;
         }
 
         public async Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
         {
-            await _kafkaTopicManager.EnsureTopicExistsAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC);
+            await _kafkaTopicManager.EnsureTopicExistsAsync(_telemetryDeviceStatusConfiguration.TopicName);
 
             List<TelemetryDeviceStatusDto> statusDtos = telemetryDevices
                 .Select(td => new TelemetryDeviceStatusDto(td))
@@ -34,7 +40,7 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
             };
 
             await _producer.ProduceAsync(
-                TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC,
+                _telemetryDeviceStatusConfiguration.TopicName,
                 kafkaMessage
             );
         }

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -1,5 +1,7 @@
 using Confluent.Kafka;
+using Newtonsoft.Json;
 using TelemetryDevices.Common;
+using TelemetryDevices.Dto;
 using TelemetryDevices.Models;
 using TelemetryDevices.Services.Kafka.Topic_Manager;
 
@@ -20,13 +22,15 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
         {
             await _kafkaTopicManager.EnsureTopicExistsAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC);
 
-            string fullStatusMessage = string.Join(
-                TelemetryDeviceConstants.TextHelpers.LINE_DOWN_SEPARATOR,
-                telemetryDevices.Select(td => td.GetStatus())
-            );
+            List<TelemetryDeviceStatusDto> statusDtos = telemetryDevices
+                .Select(td => new TelemetryDeviceStatusDto(td))
+                .ToList();
+
+            string jsonMessage = JsonConvert.SerializeObject(statusDtos);
+            
             var kafkaMessage = new Message<string, byte[]>
             {
-                Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
+                Value = System.Text.Encoding.UTF8.GetBytes(jsonMessage),
             };
 
             await _producer.ProduceAsync(

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -26,7 +26,7 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
             );
             var kafkaMessage = new Message<string, byte[]>
             {
-                Key = Guid.NewGuid().ToString(),
+                Key = null,
                 Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
             };
 

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -1,0 +1,26 @@
+﻿using Confluent.Kafka;
+using TelemetryDevices.Models;
+
+namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProducer
+{
+    public class TelemetryDeviceStatusProducer : ITelemetryDeviceStatusProducer
+    {
+        private readonly IProducer<string, byte[]> _producer;
+
+        public TelemetryDeviceStatusProducer(IProducer<string, byte[]> producer)
+        {
+            _producer = producer;
+        }
+
+        public Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
+        {
+            string fullStatusMessage = string.Join("\n", telemetryDevices.Select(td => td.GetStatus()));
+            var kafkaMessage = new Message<string, byte[]>
+            {
+                Key = Guid.NewGuid().ToString(),
+                Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
+            };
+            return _producer.ProduceAsync("telemetry-device-status", kafkaMessage);
+        }
+    }
+}

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -15,13 +15,19 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
 
         public Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
         {
-            string fullStatusMessage = string.Join("\n", telemetryDevices.Select(td => td.GetStatus()));
+            string fullStatusMessage = string.Join(
+                TelemetryDeviceConstants.TextHelpers.LINE_DOWN_SEPARATOR,
+                telemetryDevices.Select(td => td.GetStatus())
+            );
             var kafkaMessage = new Message<string, byte[]>
             {
                 Key = Guid.NewGuid().ToString(),
                 Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
             };
-            return _producer.ProduceAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC, kafkaMessage);
+            return _producer.ProduceAsync(
+                TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC,
+                kafkaMessage
+            );
         }
     }
 }

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -1,0 +1,27 @@
+﻿using Confluent.Kafka;
+using TelemetryDevices.Common;
+using TelemetryDevices.Models;
+
+namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProducer
+{
+    public class TelemetryDeviceStatusProducer : ITelemetryDeviceStatusProducer
+    {
+        private readonly IProducer<string, byte[]> _producer;
+
+        public TelemetryDeviceStatusProducer(IProducer<string, byte[]> producer)
+        {
+            _producer = producer;
+        }
+
+        public Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
+        {
+            string fullStatusMessage = string.Join("\n", telemetryDevices.Select(td => td.GetStatus()));
+            var kafkaMessage = new Message<string, byte[]>
+            {
+                Key = Guid.NewGuid().ToString(),
+                Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
+            };
+            return _producer.ProduceAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC, kafkaMessage);
+        }
+    }
+}

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -26,7 +26,6 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
             );
             var kafkaMessage = new Message<string, byte[]>
             {
-                Key = null,
                 Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
             };
 

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryDevicesStatusProducer/TelemetryDeviceStatusProducer.cs
@@ -1,16 +1,19 @@
 using Confluent.Kafka;
 using TelemetryDevices.Common;
 using TelemetryDevices.Models;
+using TelemetryDevices.Services.Kafka.Topic_Manager;
 
 namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProducer
 {
     public class TelemetryDeviceStatusProducer : ITelemetryDeviceStatusProducer
     {
         private readonly IProducer<string, byte[]> _producer;
+        private readonly IKafkaTopicManager _kafkaTopicManager;
 
-        public TelemetryDeviceStatusProducer(IProducer<string, byte[]> producer)
+        public TelemetryDeviceStatusProducer(IProducer<string, byte[]> producer,IKafkaTopicManager kafkaTopicManager)
         {
             _producer = producer;
+            _kafkaTopicManager = kafkaTopicManager;
         }
 
         public Task ProduceAsync(IEnumerable<TelemetryDevice> telemetryDevices)
@@ -24,6 +27,8 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProduc
                 Key = Guid.NewGuid().ToString(),
                 Value = System.Text.Encoding.UTF8.GetBytes(fullStatusMessage),
             };
+            _kafkaTopicManager.EnsureTopicExistsAsync(TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC);
+
             return _producer.ProduceAsync(
                 TelemetryDeviceConstants.Kafka.TELEMETRY_DEVICE_STATUS_TOPIC,
                 kafkaMessage

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/IKafkaTelemetryProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/IKafkaTelemetryProducer.cs
@@ -4,10 +4,12 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryProducer
 {
     public interface IKafkaTelemetryProducer
     {
-        public Task ProduceAsync(string topicName,
+        public Task ProduceAsync(
+            string topicName,
             int partition,
             string messageKey,
             int tailId,
-            IEnumerable<KeyValuePair<TelemetryFields, double>> telemetryData);
+            IEnumerable<KeyValuePair<TelemetryFields, double>> telemetryData
+        );
     }
 }

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/IKafkaTelemetryProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/IKafkaTelemetryProducer.cs
@@ -1,6 +1,6 @@
 ﻿using Core.Common.Enums;
 
-namespace TelemetryDevices.Services.Kafka.Producers
+namespace TelemetryDevices.Services.Kafka.Producers.TelemetryProducer
 {
     public interface IKafkaTelemetryProducer
     {

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/KafkaTelemetryProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/KafkaTelemetryProducer.cs
@@ -1,7 +1,7 @@
-﻿using Confluent.Kafka;
+﻿using System.Text;
+using Confluent.Kafka;
 using Core.Common.Enums;
 using Newtonsoft.Json;
-using System.Text;
 using TelemetryDevices.Common;
 using TelemetryDevices.Services.Kafka.Topic_Manager;
 
@@ -12,7 +12,10 @@ namespace TelemetryDevices.Services.Kafka.Producers.TelemetryProducer
         private readonly IProducer<string, byte[]> _producer;
         private readonly IKafkaTopicManager _kafkaTopicManager;
 
-        public KafkaTelemetryProducer(ProducerConfig producerConfig,IKafkaTopicManager kafkaTopicManager)
+        public KafkaTelemetryProducer(
+            ProducerConfig producerConfig,
+            IKafkaTopicManager kafkaTopicManager
+        )
         {
             _producer = new ProducerBuilder<string, byte[]>(producerConfig).Build();
             _kafkaTopicManager = kafkaTopicManager;

--- a/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/KafkaTelemetryProducer.cs
+++ b/TelemetryDevice/Services/Kafka/Producers/TelemetryProducer/KafkaTelemetryProducer.cs
@@ -5,7 +5,7 @@ using System.Text;
 using TelemetryDevices.Common;
 using TelemetryDevices.Services.Kafka.Topic_Manager;
 
-namespace TelemetryDevices.Services.Kafka.Producers
+namespace TelemetryDevices.Services.Kafka.Producers.TelemetryProducer
 {
     public class KafkaTelemetryProducer : IKafkaTelemetryProducer
     {

--- a/TelemetryDevice/Services/PipeLines/Blocks/Output/Kafka/KafkaTelemetryOutputBlock.cs
+++ b/TelemetryDevice/Services/PipeLines/Blocks/Output/Kafka/KafkaTelemetryOutputBlock.cs
@@ -3,7 +3,7 @@ using Core.Common.Enums;
 using Core.Models.ICDModels;
 using TelemetryDevices.Common;
 using TelemetryDevices.Models;
-using TelemetryDevices.Services.Kafka.Producers;
+using TelemetryDevices.Services.Kafka.Producers.TelemetryProducer;
 
 namespace TelemetryDevices.Services.PipeLines.Blocks.Output.Kafka
 {

--- a/TelemetryDevice/Services/PipeLines/Blocks/Validator/CheckSum/ChecksumTelemetryValidatorBlock.cs
+++ b/TelemetryDevice/Services/PipeLines/Blocks/Validator/CheckSum/ChecksumTelemetryValidatorBlock.cs
@@ -29,10 +29,8 @@ namespace TelemetryDevices.Services.PipeLines.Blocks.Validator.CheckSum
             int paddingBitsLength =
                 (
                     TelemetryDeviceConstants.TelemetryCompression.BYTE_ALIGNMENT
-                    - 
-                        dataPlusChecksumBits
+                    - dataPlusChecksumBits
                         % TelemetryDeviceConstants.TelemetryCompression.BYTE_ALIGNMENT
-                    
                 ) % TelemetryDeviceConstants.TelemetryCompression.BYTE_ALIGNMENT;
             int expectedTotalBits = dataBitsLength + checksumBitsLength + paddingBitsLength;
 

--- a/TelemetryDevice/Services/PipeLines/TelemetryPipeline.cs
+++ b/TelemetryDevice/Services/PipeLines/TelemetryPipeline.cs
@@ -18,7 +18,6 @@ namespace TelemetryDevices.Services.PipeLines
         private ActionBlock<DecodingResult> _pipelineOutputBlock;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private int? _currentTailId;
-        private bool _isDisposed;
 
         public TelemetryPipeline(
             ITelemetryValidatorBlock telemetryValidatorBlock,
@@ -92,9 +91,6 @@ namespace TelemetryDevices.Services.PipeLines
 
         public async Task ProcessTelemetryDataAsync(byte[] telemetryData)
         {
-            if (_isDisposed)
-                throw new ObjectDisposedException(nameof(TelemetryPipeline));
-
             bool posted = await _pipelineValidatorBlock.SendAsync(
                 telemetryData,
                 _cancellationTokenSource.Token
@@ -121,13 +117,9 @@ namespace TelemetryDevices.Services.PipeLines
 
         public void Dispose()
         {
-            if (_isDisposed)
-                return;
-
             _cancellationTokenSource.Cancel();
             _pipelineValidatorBlock.Complete();
             _cancellationTokenSource.Dispose();
-            _isDisposed = true;
         }
     }
 }

--- a/TelemetryDevice/Services/PipeLines/TelemetryPipeline.cs
+++ b/TelemetryDevice/Services/PipeLines/TelemetryPipeline.cs
@@ -43,7 +43,8 @@ namespace TelemetryDevices.Services.PipeLines
             );
 
             _pipelineDecoderBlock = new TransformBlock<ValidationResult, DecodingResult>(
-                validationResult => DecodeAndNotifyTailIdChange(validationResult, telemetryIcd, onTailIdChanged),
+                validationResult =>
+                    DecodeAndNotifyTailIdChange(validationResult, telemetryIcd, onTailIdChanged),
                 new ExecutionDataflowBlockOptions
                 {
                     CancellationToken = _cancellationTokenSource.Token,
@@ -64,9 +65,13 @@ namespace TelemetryDevices.Services.PipeLines
         private DecodingResult DecodeAndNotifyTailIdChange(
             ValidationResult validationResult,
             ICD telemetryIcd,
-            Action<int> onTailIdDecoded)
+            Action<int> onTailIdDecoded
+        )
         {
-            DecodingResult result = _telemetryDecoderBlock.DecodeTelemetryData(validationResult, telemetryIcd);
+            DecodingResult result = _telemetryDecoderBlock.DecodeTelemetryData(
+                validationResult,
+                telemetryIcd
+            );
             int decodedTailId = ExtractTailId(result);
             NotifyTailIdChangeIfNeeded(decodedTailId, onTailIdDecoded);
             return result;
@@ -79,7 +84,8 @@ namespace TelemetryDevices.Services.PipeLines
 
         private void NotifyTailIdChangeIfNeeded(int decodedTailId, Action<int> onTailIdDecoded)
         {
-            if (_currentTailId == decodedTailId) return;
+            if (_currentTailId == decodedTailId)
+                return;
             _currentTailId = decodedTailId;
             onTailIdDecoded(decodedTailId);
         }

--- a/TelemetryDevice/Services/PortsManager/PortManager.cs
+++ b/TelemetryDevice/Services/PortsManager/PortManager.cs
@@ -1,5 +1,4 @@
 using TelemetryDevices.Models;
-using TelemetryDevices.Services.Helpers;
 using TelemetryDevices.Services.Sniffer;
 
 namespace TelemetryDevices.Services.PortsManager

--- a/TelemetryDevice/Services/Quartz/Jobs/TelemetryDeviceStatusJob.cs
+++ b/TelemetryDevice/Services/Quartz/Jobs/TelemetryDeviceStatusJob.cs
@@ -1,5 +1,7 @@
 ﻿using Quartz;
+using TelemetryDevices.Models;
 using TelemetryDevices.Services.Kafka.Producers;
+using TelemetryDevices.Services.Kafka.Producers.TelemetryDevicesStatusProducer;
 using TelemetryDevices.Services.TelemetryDevicesManager;
 
 namespace TelemetryDevices.Services.Quartz.Jobs
@@ -7,7 +9,19 @@ namespace TelemetryDevices.Services.Quartz.Jobs
     public class TelemetryDeviceStatusJob : IJob
     {
         private readonly ITelemetryDeviceManager _telemetryDeviceManager;
+        private readonly ITelemetryDeviceStatusProducer _telemetryDeviceStatusProducer;
 
-        public Task Execute(IJobExecutionContext context) { }
+        public TelemetryDeviceStatusJob(ITelemetryDeviceManager telemetryDeviceManager,ITelemetryDeviceStatusProducer telemetryDeviceStatusProducer)
+        {
+            _telemetryDeviceManager = telemetryDeviceManager;
+            _telemetryDeviceStatusProducer = telemetryDeviceStatusProducer;
+        }
+
+        public Task Execute(IJobExecutionContext context)
+        {
+            IEnumerable<TelemetryDevice> telemetryDevices = _telemetryDeviceManager.GetAllTelemetryDevices();
+            _telemetryDeviceStatusProducer.ProduceAsync(telemetryDevices);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/TelemetryDevice/Services/Quartz/Jobs/TelemetryDeviceStatusJob.cs
+++ b/TelemetryDevice/Services/Quartz/Jobs/TelemetryDeviceStatusJob.cs
@@ -1,0 +1,15 @@
+﻿using Quartz;
+using TelemetryDevices.Services.Kafka.Producers;
+using TelemetryDevices.Services.TelemetryDevicesManager;
+
+namespace TelemetryDevices.Services.Quartz.Jobs
+{
+    public class TelemetryDeviceStatusJob : IJob
+    {
+        private readonly ITelemetryDeviceManager _telemetryDeviceManager;
+        public Task Execute(IJobExecutionContext context)
+        {
+            
+        }
+    }
+}

--- a/TelemetryDevice/Services/Quartz/Jobs/TelemetryDeviceStatusJob.cs
+++ b/TelemetryDevice/Services/Quartz/Jobs/TelemetryDeviceStatusJob.cs
@@ -7,9 +7,7 @@ namespace TelemetryDevices.Services.Quartz.Jobs
     public class TelemetryDeviceStatusJob : IJob
     {
         private readonly ITelemetryDeviceManager _telemetryDeviceManager;
-        public Task Execute(IJobExecutionContext context)
-        {
-            
-        }
+
+        public Task Execute(IJobExecutionContext context) { }
     }
 }

--- a/TelemetryDevice/Services/Quartz/TelemetryDeviceStatusManager/IQuartzTelemetryDeviceStatusManager.cs
+++ b/TelemetryDevice/Services/Quartz/TelemetryDeviceStatusManager/IQuartzTelemetryDeviceStatusManager.cs
@@ -1,0 +1,8 @@
+﻿namespace TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager
+{
+    public interface IQuartzTelemetryDeviceStatusManager
+    {
+        Task<bool> StartSchedular(int intervalSeconds);
+        Task<bool> StopSchedular();
+    }
+}

--- a/TelemetryDevice/Services/Quartz/TelemetryDeviceStatusManager/QuartzTelemetryDeviceStatusManager.cs
+++ b/TelemetryDevice/Services/Quartz/TelemetryDeviceStatusManager/QuartzTelemetryDeviceStatusManager.cs
@@ -15,8 +15,8 @@ namespace TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager
 
         public async Task<bool> StartSchedular(int intervalSeconds)
         {
-            IJobDetail job = CreateJob();
-            ITrigger trigger = CreateTrigger(intervalSeconds);
+            IJobDetail job = CreateTelemetryDeviceStatusJob();
+            ITrigger trigger = CreateTelemetryDeviceStatusTrigger(intervalSeconds);
 
             await _scheduler.ScheduleJob(job, trigger);
             await _scheduler.Start();
@@ -44,7 +44,7 @@ namespace TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager
             return true;
         }
 
-        private IJobDetail CreateJob()
+        private IJobDetail CreateTelemetryDeviceStatusJob()
         {
             return JobBuilder.Create<TelemetryDeviceStatusJob>()
                 .WithIdentity(
@@ -54,7 +54,7 @@ namespace TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager
                 .Build();
         }
 
-        private ITrigger CreateTrigger(int intervalSeconds)
+        private ITrigger CreateTelemetryDeviceStatusTrigger(int intervalSeconds)
         {
             return TriggerBuilder.Create()
                 .WithIdentity(

--- a/TelemetryDevice/Services/Quartz/TelemetryDeviceStatusManager/QuartzTelemetryDeviceStatusManager.cs
+++ b/TelemetryDevice/Services/Quartz/TelemetryDeviceStatusManager/QuartzTelemetryDeviceStatusManager.cs
@@ -1,0 +1,71 @@
+﻿using Quartz;
+using TelemetryDevices.Common;
+using TelemetryDevices.Services.Quartz.Jobs;
+
+namespace TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager
+{
+    public class QuartzTelemetryDeviceStatusManager : IQuartzTelemetryDeviceStatusManager
+    {
+        private readonly IScheduler _scheduler;
+
+        public QuartzTelemetryDeviceStatusManager(IScheduler scheduler)
+        {
+            _scheduler = scheduler;
+        }
+
+        public async Task<bool> StartSchedular(int intervalSeconds)
+        {
+            IJobDetail job = CreateJob();
+            ITrigger trigger = CreateTrigger(intervalSeconds);
+
+            await _scheduler.ScheduleJob(job, trigger);
+            await _scheduler.Start();
+
+            return true;
+        }
+
+        public async Task<bool> StopSchedular()
+        {
+            JobKey jobKey = new JobKey(
+                TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_JOB_KEY,
+                TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_GROUP_NAME
+            );
+
+            if (await _scheduler.CheckExists(jobKey))
+            {
+                await _scheduler.DeleteJob(jobKey);
+            }
+
+            if (_scheduler.IsStarted)
+            {
+                await _scheduler.Shutdown();
+            }
+
+            return true;
+        }
+
+        private IJobDetail CreateJob()
+        {
+            return JobBuilder.Create<TelemetryDeviceStatusJob>()
+                .WithIdentity(
+                    TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_JOB_KEY,
+                    TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_GROUP_NAME
+                )
+                .Build();
+        }
+
+        private ITrigger CreateTrigger(int intervalSeconds)
+        {
+            return TriggerBuilder.Create()
+                .WithIdentity(
+                    TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_TRIGGER_KEY,
+                    TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_GROUP_NAME
+                )
+                .StartNow()
+                .WithSimpleSchedule(schedule =>
+                    schedule.WithIntervalInSeconds(intervalSeconds)
+                            .RepeatForever())
+                .Build();
+        }
+    }
+}

--- a/TelemetryDevice/Services/TelemetryDevicesManager/ITelemetryDeviceManager.cs
+++ b/TelemetryDevice/Services/TelemetryDevicesManager/ITelemetryDeviceManager.cs
@@ -4,11 +4,7 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
 {
     public interface ITelemetryDeviceManager
     {
-        public Task AddTelemetryDeviceAsync(
-            int tailId,
-            List<int> portNumbers,
-            Location location
-        );
+        public Task AddTelemetryDeviceAsync(int tailId, List<int> portNumbers, Location location);
 
         public bool RemoveTelemetryDevice(int tailId);
 

--- a/TelemetryDevice/Services/TelemetryDevicesManager/TelemetryDeviceManager.cs
+++ b/TelemetryDevice/Services/TelemetryDevicesManager/TelemetryDeviceManager.cs
@@ -16,7 +16,7 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
         private readonly IPortManager _portManager;
         private readonly IServiceProvider _serviceProvider;
         private readonly IQuartzTelemetryDeviceStatusManager _quartzTelemetryDeviceStatusManager;
-        private readonly TelemetryDeviceStatusConfiguration _configuration;
+        private readonly TelemetryDeviceStatusConfiguration _telemetryDeviceStatusConfiguration;
         private bool _isSchedulerStarted;
 
         public TelemetryDeviceManager(
@@ -31,7 +31,7 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
             _portManager = portManager;
             _serviceProvider = serviceProvider;
             _quartzTelemetryDeviceStatusManager = quartzTelemetryDeviceStatusManager;
-            _configuration = configuration.Value;
+            _telemetryDeviceStatusConfiguration = configuration.Value;
             _telemetryDevicesByTailId = new Dictionary<int, TelemetryDevice>();
             _isSchedulerStarted = false;
         }
@@ -57,7 +57,7 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
             if (!_isSchedulerStarted)
             {
                 await _quartzTelemetryDeviceStatusManager.StartSchedular(
-                    _configuration.JobInterval
+                    _telemetryDeviceStatusConfiguration.JobInterval
                 );
                 _isSchedulerStarted = true;
             }

--- a/TelemetryDevice/Services/TelemetryDevicesManager/TelemetryDeviceManager.cs
+++ b/TelemetryDevice/Services/TelemetryDevicesManager/TelemetryDeviceManager.cs
@@ -1,6 +1,7 @@
 ﻿using Core.Models.ICDModels;
 using Core.Services.ICDsDirectory;
-using TelemetryDevices.Common;
+using Microsoft.Extensions.Options;
+using TelemetryDevices.Config;
 using TelemetryDevices.Models;
 using TelemetryDevices.Services.PipeLines;
 using TelemetryDevices.Services.PortsManager;
@@ -15,19 +16,22 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
         private readonly IPortManager _portManager;
         private readonly IServiceProvider _serviceProvider;
         private readonly IQuartzTelemetryDeviceStatusManager _quartzTelemetryDeviceStatusManager;
+        private readonly TelemetryDeviceStatusConfiguration _configuration;
         private bool _isSchedulerStarted;
 
         public TelemetryDeviceManager(
             IICDDirectory icdDirectory,
             IPortManager portManager,
             IServiceProvider serviceProvider,
-            IQuartzTelemetryDeviceStatusManager quartzTelemetryDeviceStatusManager
+            IQuartzTelemetryDeviceStatusManager quartzTelemetryDeviceStatusManager,
+            IOptions<TelemetryDeviceStatusConfiguration> configuration
         )
         {
             _icdDirectory = icdDirectory;
             _portManager = portManager;
             _serviceProvider = serviceProvider;
             _quartzTelemetryDeviceStatusManager = quartzTelemetryDeviceStatusManager;
+            _configuration = configuration.Value;
             _telemetryDevicesByTailId = new Dictionary<int, TelemetryDevice>();
             _isSchedulerStarted = false;
         }
@@ -53,7 +57,7 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
             if (!_isSchedulerStarted)
             {
                 await _quartzTelemetryDeviceStatusManager.StartSchedular(
-                    TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_JOB_INTERVAL
+                    _configuration.JobInterval
                 );
                 _isSchedulerStarted = true;
             }

--- a/TelemetryDevice/Services/TelemetryDevicesManager/TelemetryDeviceManager.cs
+++ b/TelemetryDevice/Services/TelemetryDevicesManager/TelemetryDeviceManager.cs
@@ -2,9 +2,9 @@
 using Core.Services.ICDsDirectory;
 using TelemetryDevices.Common;
 using TelemetryDevices.Models;
-using TelemetryDevices.Services.Kafka.Topic_Manager;
 using TelemetryDevices.Services.PipeLines;
 using TelemetryDevices.Services.PortsManager;
+using TelemetryDevices.Services.Quartz.TelemetryDeviceStatusManager;
 
 namespace TelemetryDevices.Services.TelemetryDevicesManager
 {
@@ -14,17 +14,22 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
         private readonly IICDDirectory _icdDirectory;
         private readonly IPortManager _portManager;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IQuartzTelemetryDeviceStatusManager _quartzTelemetryDeviceStatusManager;
+        private bool _isSchedulerStarted;
 
         public TelemetryDeviceManager(
             IICDDirectory icdDirectory,
             IPortManager portManager,
-            IServiceProvider serviceProvider
+            IServiceProvider serviceProvider,
+            IQuartzTelemetryDeviceStatusManager quartzTelemetryDeviceStatusManager
         )
         {
             _icdDirectory = icdDirectory;
             _portManager = portManager;
             _serviceProvider = serviceProvider;
+            _quartzTelemetryDeviceStatusManager = quartzTelemetryDeviceStatusManager;
             _telemetryDevicesByTailId = new Dictionary<int, TelemetryDevice>();
+            _isSchedulerStarted = false;
         }
 
         public async Task AddTelemetryDeviceAsync(
@@ -39,6 +44,19 @@ namespace TelemetryDevices.Services.TelemetryDevicesManager
 
             List<ICD> availableIcds = _icdDirectory.GetAllICDs();
             CreateTelemetryChannelsForDevice(newTelemetryDevice, portNumbers, availableIcds);
+
+            await StartSchedulerIfNeeded();
+        }
+
+        private async Task StartSchedulerIfNeeded()
+        {
+            if (!_isSchedulerStarted)
+            {
+                await _quartzTelemetryDeviceStatusManager.StartSchedular(
+                    TelemetryDeviceConstants.Quartz.TELEMETRY_DEVICE_STATUS_UPDATE_JOB_INTERVAL
+                );
+                _isSchedulerStarted = true;
+            }
         }
 
         private void ValidateTelemetryDeviceDoesNotExist(int tailId)

--- a/TelemetryDevice/TelemetryDevices.csproj
+++ b/TelemetryDevice/TelemetryDevices.csproj
@@ -22,7 +22,10 @@
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.15.0" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.15.0" />
     <PackageReference Include="SharpPcap" Version="6.3.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.0-preview.6.25358.103" />
+    <PackageReference
+      Include="System.Threading.Tasks.Dataflow"
+      Version="10.0.0-preview.6.25358.103"
+    />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />

--- a/TelemetryDevice/TelemetryDevices.csproj
+++ b/TelemetryDevice/TelemetryDevices.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4-beta1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
     <PackageReference Include="PacketDotNet" Version="1.4.8" />
+    <PackageReference Include="Quartz" Version="3.15.0" />
+    <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.15.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.15.0" />
     <PackageReference Include="SharpPcap" Version="6.3.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.0-preview.6.25358.103" />
   </ItemGroup>

--- a/TelemetryDevice/TelemetryDevices.csproj
+++ b/TelemetryDevice/TelemetryDevices.csproj
@@ -27,7 +27,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Services\Quartz\Jobs\" />
-  </ItemGroup>
 </Project>

--- a/TelemetryDevice/TelemetryDevices.csproj
+++ b/TelemetryDevice/TelemetryDevices.csproj
@@ -22,10 +22,7 @@
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.15.0" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.15.0" />
     <PackageReference Include="SharpPcap" Version="6.3.1" />
-    <PackageReference
-      Include="System.Threading.Tasks.Dataflow"
-      Version="10.0.0-preview.6.25358.103"
-    />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.0-preview.6.25358.103" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />

--- a/TelemetryDevice/appsettings.json
+++ b/TelemetryDevice/appsettings.json
@@ -15,5 +15,9 @@
   "Kafka": {
     "BootstrapServers": "localhost:9092"
   },
+  "TelemetryDeviceStatusUpdate": {
+    "JobInterval": 5,
+    "TopicName": "telemetry-device-status"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Adds the telemetry device status producer to periodically send device status updates to a Kafka topic.

- Introduces a scheduled job to fetch and send telemetry device status.
- Configures the job interval and Kafka topic via `appsettings.json`.
- Utilizes a DTO for message serialization.